### PR TITLE
Fix bugs and update get calculate sphere position function

### DIFF
--- a/src/Utils/segmentation/CommToolsData.ts
+++ b/src/Utils/segmentation/CommToolsData.ts
@@ -6,7 +6,7 @@ import {
   ICursorPage,
   IPaintImages,
   IConvertObjType,
-  ICommXYZ,
+  ICommXYZ
 } from "./coreTools/coreType";
 import { switchPencilIcon } from "../utils";
 import { enableDownload } from "./coreTools/divControlTools";
@@ -47,10 +47,10 @@ export class CommToolsData {
     skinSphereOrigin: null,
     ribSphereOrigin: null,
     nippleSphereOrigin: null,
-    tumourColor: "#00ff00",
-    skinColor: "#FFEB3B",
-    ribcageColor: "#2196F3",
-    nippleColor: "#E91E63",
+    tumourColor:"#00ff00",
+    skinColor:"#FFEB3B",
+    ribcageColor:"#2196F3",
+    nippleColor:"#E91E63",
 
     spherePlanB: true,
     sphereRadius: 10,
@@ -74,12 +74,7 @@ export class CommToolsData {
       clearAllFlag: boolean
     ) => {},
     getSphere: (sphereOrigin: number[], sphereRadius: number) => {},
-    getCalculateSpherePositions: (
-      tumourSphereOrigin: ICommXYZ | null,
-      skinSphereOrigin: ICommXYZ | null,
-      ribSphereOrigin: ICommXYZ | null,
-      nippleSphereOrigin: ICommXYZ | null
-    ) => {},
+    getCalculateSpherePositions:(tumourSphereOrigin:ICommXYZ|null, skinSphereOrigin:ICommXYZ|null, ribSphereOrigin:ICommXYZ|null, nippleSphereOrigin:ICommXYZ|null, aixs:"x"|"y"|"z")=>{},
     drawStartPos: { x: 1, y: 1 },
   };
 
@@ -102,7 +97,7 @@ export class CommToolsData {
       index: 0,
       updated: false,
     },
-  };
+  }; 
 
   gui_states: IGUIStates = {
     mainAreaSize: 3,
@@ -117,9 +112,9 @@ export class CommToolsData {
     brushAndEraserSize: 15,
     cursor: "dot",
     label: "label1",
-    cal_distance: "tumour",
+    cal_distance:"tumour",
     sphere: false,
-    calculator: false,
+    calculator:false,
     readyToUpdate: true,
     defaultPaintCursor: switchPencilIcon("dot"),
     max_sensitive: 100,
@@ -169,7 +164,7 @@ export class CommToolsData {
       currentShowingSlice: undefined,
       mainPreSlices: undefined,
       Is_Shift_Pressed: false,
-      Is_Ctrl_Pressed: false,
+      Is_Ctrl_Pressed:false,
       Is_Draw: false,
       axis: "z",
       maskData: {
@@ -252,7 +247,10 @@ export class CommToolsData {
   /**
    * Rewrite this {createEmptyPaintImage} function under NrrdTools
    */
-  createEmptyPaintImage(dimensions: Array<number>, paintImages: IPaintImages) {
+  createEmptyPaintImage(
+    dimensions: Array<number>,
+    paintImages: IPaintImages
+  ) {
     throw new Error(
       "Child class must implement abstract clearStoreImages, currently you can find it in NrrdTools."
     );

--- a/src/Utils/segmentation/NrrdTools.ts
+++ b/src/Utils/segmentation/NrrdTools.ts
@@ -345,12 +345,19 @@ export class NrrdTools extends DrawToolCore {
   }
 
   // set calculate distance sphere position
-  set_calculate_distance_sphere(x:number, y:number, sliceIndex:number, cal_position:"tumour"|"skin"|"nipple"|"ribcage"){
+  setCalculateDistanceSphere(x:number, y:number, sliceIndex:number, cal_position:"tumour"|"skin"|"nipple"|"ribcage"){
     this.nrrd_states.sphereRadius = 5;
-    this.draw_cal_sphere(x, y, sliceIndex, cal_position);
-    this.drawCalculatorSphereOnEachViews("x");
-    this.drawCalculatorSphereOnEachViews("y");
-    this.drawCalculatorSphereOnEachViews("z");
+    
+    // move to tumour slice
+    const steps = sliceIndex - this.nrrd_states.currentIndex;
+    this.setSliceMoving(steps * this.protectedData.displaySlices.length)
+
+    // mock mouse down
+    // if user zoom the panel, we need to consider the size factor 
+    this.drawCalSphereDown(x*this.nrrd_states.sizeFoctor, y*this.nrrd_states.sizeFoctor, sliceIndex, cal_position);
+    // mock mouse up
+    this.drawCalSphereUp()
+
   }
 
   private getSharedPlace(len: number, ratio: number): number[] {
@@ -867,10 +874,13 @@ export class NrrdTools extends DrawToolCore {
     this.nrrd_states.originHeight =
       this.protectedData.canvases.originCanvas.height;
 
+    // In html the width and height is pixels,
+    // So the value must be int
+    // Therefore, we must use Math.floor rather than using Math.ceil
     this.nrrd_states.changedWidth =
-      this.nrrd_states.originWidth * Number(this.nrrd_states.sizeFoctor);
+      Math.floor(this.nrrd_states.originWidth * Number(this.nrrd_states.sizeFoctor));
     this.nrrd_states.changedHeight =
-      this.nrrd_states.originWidth * Number(this.nrrd_states.sizeFoctor);
+      Math.floor(this.nrrd_states.originWidth * Number(this.nrrd_states.sizeFoctor));
     this.resizePaintArea(this.nrrd_states.sizeFoctor);
     this.resetPaintAreaUIPosition();
   }
@@ -985,8 +995,8 @@ export class NrrdTools extends DrawToolCore {
       this.protectedData.canvases.drawingCanvas.width;
     this.resetLayerCanvas();
 
-    this.nrrd_states.changedWidth = this.nrrd_states.originWidth * factor;
-    this.nrrd_states.changedHeight = this.nrrd_states.originHeight * factor;
+    this.nrrd_states.changedWidth = Math.floor(this.nrrd_states.originWidth * factor);
+    this.nrrd_states.changedHeight = Math.floor(this.nrrd_states.originHeight * factor);
 
     /**
      * resize canvas

--- a/src/Utils/segmentation/coreTools/coreType.ts
+++ b/src/Utils/segmentation/coreTools/coreType.ts
@@ -48,8 +48,8 @@ interface IDrawingEvents {
 }
 
 interface IContrastEvents {
-  move_x: number;
-  move_y: number;
+  move_x:number;
+  move_y:number;
   x: number;
   y: number;
   w: number;
@@ -57,7 +57,7 @@ interface IContrastEvents {
   handleOnContrastMouseDown: (ev: MouseEvent) => void;
   handleOnContrastMouseMove: (ev: MouseEvent) => void;
   handleOnContrastMouseUp: (ev: MouseEvent) => void;
-  handleOnContrastMouseLeave: (ev: MouseEvent) => void;
+  handleOnContrastMouseLeave:(ev: MouseEvent) => void;
 }
 
 // drawing on canvas
@@ -94,7 +94,7 @@ interface IProtected {
   currentShowingSlice: any;
   mainPreSlices: any;
   Is_Shift_Pressed: boolean;
-  Is_Ctrl_Pressed: boolean;
+  Is_Ctrl_Pressed:boolean;
   Is_Draw: boolean;
   axis: "x" | "y" | "z";
   maskData: IMaskData;
@@ -136,9 +136,9 @@ interface IGUIStates {
   brushAndEraserSize: number;
   cursor: string;
   label: string;
-  cal_distance: "tumour" | "skin" | "nipple" | "ribcage";
+  cal_distance:"tumour" | "skin" | "nipple" | "ribcage";
   sphere: boolean;
-  calculator: boolean;
+  calculator:boolean;
   // subView: boolean;
   // subViewScale: number;
   readyToUpdate: boolean;
@@ -182,14 +182,14 @@ interface INrrdStates {
   cursorPageX: number;
   cursorPageY: number;
   sphereOrigin: ICommXYZ;
-  tumourSphereOrigin: ICommXYZ | null;
-  skinSphereOrigin: ICommXYZ | null;
-  ribSphereOrigin: ICommXYZ | null;
-  nippleSphereOrigin: ICommXYZ | null;
-  tumourColor: "#00ff00";
-  skinColor: "#FFEB3B";
-  ribcageColor: "#2196F3";
-  nippleColor: "#E91E63";
+  tumourSphereOrigin: ICommXYZ | null,
+  skinSphereOrigin: ICommXYZ | null,
+  ribSphereOrigin: ICommXYZ | null,
+  nippleSphereOrigin: ICommXYZ | null,
+  tumourColor:"#00ff00",
+  skinColor:"#FFEB3B",
+  ribcageColor:"#2196F3",
+  nippleColor:"#E91E63",
   spherePlanB: boolean;
   sphereRadius: number;
   Mouse_Over_x: number;
@@ -212,12 +212,7 @@ interface INrrdStates {
     clearAllFlag: boolean
   ) => void;
   getSphere: (sphereOrigin: number[], sphereRadius: number) => void;
-  getCalculateSpherePositions: (
-    tumourSphereOrigin: ICommXYZ | null,
-    skinSphereOrigin: ICommXYZ | null,
-    ribSphereOrigin: ICommXYZ | null,
-    nippleSphereOrigin: ICommXYZ | null
-  ) => void;
+  getCalculateSpherePositions:(tumourSphereOrigin:ICommXYZ|null, skinSphereOrigin:ICommXYZ|null, ribSphereOrigin:ICommXYZ|null, nippleSphereOrigin:ICommXYZ|null, aixs:"x"|"y"|"z")=>void,
   drawStartPos: ICommXY;
 }
 
@@ -236,6 +231,7 @@ interface IDrawOpts {
     clearAllFlag?: boolean
   ) => void;
   getSphereData?: (sphereOrigin: number[], sphereRadius: number) => void;
+  getCalculateSpherePositionsData?:(tumourSphereOrigin:ICommXYZ|null, skinSphereOrigin:ICommXYZ|null, ribSphereOrigin:ICommXYZ|null, nippleSphereOrigin:ICommXYZ|null, aixs:"x"|"y"|"z")=>void;
 }
 type UndoLayerType = {
   label1: Array<HTMLImageElement>;
@@ -271,111 +267,111 @@ interface ICursorPage {
 
 interface IGuiParameterSettings {
   globalAlpha: {
-    name: "Opacity";
-    min: number;
-    max: number;
-    step: number;
-  };
+    name: "Opacity",
+    min:  number,
+    max: number,
+    step: number,
+  },
   segmentation: {
-    name: "Pencil";
-    onChange: () => void;
-  };
+    name: "Pencil",
+    onChange: ()=>void,
+  },
   sphere: {
-    name: "Sphere";
-    onChange: () => void;
-  };
+    name: "Sphere",
+    onChange:  ()=>void,
+  },
   brushAndEraserSize: {
-    name: "BrushAndEraserSize";
-    min: number;
-    max: number;
-    step: number;
-    onChange: () => void;
-  };
+    name: "BrushAndEraserSize",
+    min: number,
+    max: number,
+    step: number,
+    onChange:  ()=>void,
+  },
   Eraser: {
-    name: "Eraser";
-    onChange: () => void;
-  };
-  calculator: {
-    name: "Calculator";
-    onChange: () => void;
-  };
-  cal_distance: {
-    name: "CalculatorDistance";
-    onChange: (val: "tumour" | "skin" | "ribcage" | "nipple") => void;
-  };
+    name: "Eraser",
+    onChange:  ()=>void,
+  },
+  calculator:{
+    name:"Calculator",
+    onChange: ()=>void,
+  },
+  cal_distance:{
+    name:"CalculatorDistance",
+    onChange: (val:"tumour"|"skin"|"ribcage"|"nipple")=>void
+  }
   clear: {
-    name: "Clear";
-  };
+    name: "Clear",
+  },
   clearAll: {
-    name: "ClearAll";
-  };
+    name: "ClearAll",
+  },
   undo: {
-    name: "Undo";
-  };
+    name: "Undo",
+  },
   resetZoom: {
-    name: "ResetZoom";
-  };
+    name: "ResetZoom",
+  },
   windowHigh: {
-    name: "ImageContrast";
-    value: null;
-    min: number;
-    max: number;
-    step: number;
-    onChange: (value: number) => void;
-    onFinished: () => void;
-  };
+    name: "ImageContrast",
+    value: null,
+    min: number,
+    max: number,
+    step: number,
+    onChange:  (value: number)=>void,
+    onFinished:  ()=>void,
+  },
   windowLow: {
-    name: "WindowLow";
-    value: null;
-    min: number;
-    max: number;
-    step: number;
-    onChange: (value: number) => void;
-    onFinished: () => void;
-  };
+    name: "WindowLow",
+    value: null,
+    min: number,
+    max: number,
+    step: number,
+    onChange:  (value: number)=>void,
+    onFinished:  ()=>void,
+  },
   advance: {
     label: {
-      name: "Label";
-      value: ["label1", "label2", "label3"];
-    };
+      name: "Label",
+      value: ["label1", "label2", "label3"],
+    },
     cursor: {
-      name: "CursorIcon";
-      value: ["crosshair", "pencil", "dot"];
-    };
+      name: "CursorIcon",
+      value: ["crosshair", "pencil", "dot"],
+    },
     mainAreaSize: {
-      name: "Zoom";
-      min: number;
-      max: number;
-      step: number;
-      onFinished: null;
-    };
+      name: "Zoom",
+      min: number,
+      max: number,
+      step: number,
+      onFinished: null,
+    },
     dragSensitivity: {
-      name: "DragSensitivity";
-      min: number;
-      max: number;
-      step: number;
-    };
+      name: "DragSensitivity",
+      min: number,
+      max: number,
+      step: number,
+    },
     pencilSettings: {
       lineWidth: {
-        name: "OuterLineWidth";
-        min: number;
-        max: number;
-        step: number;
-      };
+        name: "OuterLineWidth",
+        min: number,
+        max: number,
+        step: number,
+      },
       color: {
-        name: "Color";
-      };
+        name: "Color",
+      },
       fillColor: {
-        name: "FillColor";
-      };
-    };
+        name: "FillColor",
+      },
+    },
     BrushSettings: {
       brushColor: {
-        name: "BrushColor";
-      };
-    };
-  };
-}
+        name: "BrushColor",
+      },
+    },
+  },
+};
 
 export {
   ICommXYZ,
@@ -397,5 +393,5 @@ export {
   IMaskData,
   IUndoType,
   ICursorPage,
-  IGuiParameterSettings,
+  IGuiParameterSettings
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ import {
   IOptVTKLoader,
 } from "./types/types";
 
-import { IPaintImage } from "./Utils/segmentation/coreTools/coreType";
+import { IPaintImage, ICommXYZ } from "./Utils/segmentation/coreTools/coreType";
 
 import "./css/style.css";
 
@@ -90,4 +90,5 @@ export type {
   IPaintImage,
   exportPaintImageType,
   IOptVTKLoader,
+  ICommXYZ
 };


### PR DESCRIPTION
## Description:
Fixed bugs: Zoom position cannot be controlled in the sphere function
add new function 
`setCalculateDistanceSphere(x:number, y:number, sliceIndex:number, cal_position:"tumour"|"skin"|"nipple"|"ribcage")` and 
`getCalculateSpherePositions:(tumourSphereOrigin:ICommXYZ|null, skinSphereOrigin:ICommXYZ|null,ribSphereOrigin:ICommXYZ|null, nippleSphereOrigin:ICommXYZ|null, aixs:"x"|"y"|"z")`

## Related issue(s):
#301 #302 

## Test Environment:
Specify the testing enviroment. e.g. OS, Python version
